### PR TITLE
[FEATURE] Add post results filters

### DIFF
--- a/core/includes/classes/class-wp-webhooks-pro-run.php
+++ b/core/includes/classes/class-wp-webhooks-pro-run.php
@@ -3841,6 +3841,7 @@ $return_args = array(
 			}
 
 			if( $is_valid ){
+				$data_array = apply_filters( 'wpwhpro/webhooks/trigger_create_post_results', $data_array, $post );
 				$response_data[] = WPWHPRO()->webhook->post_to_webhook( $webhook, $data_array );
 			}
 		}
@@ -3937,6 +3938,7 @@ $return_args = array(
 			    }
 
 			    if( $is_valid ){
+				    $data_array = apply_filters( 'wpwhpro/webhooks/trigger_update_post_results', $data_array, $post );
 				    $response_data[] = WPWHPRO()->webhook->post_to_webhook( $webhook, $data_array );
 			    }
 		    }


### PR DESCRIPTION
# Overview
The goal of this PR is to add filters to the post results. These filters can be used to modify the result sent via webhook.

# Our use case
 * We're using `wp-graphql` as a backend for a mobile app
 * `wp-webhooks` allows us to send webhooks when posts are created/updated and marked for an app notification

Filtering the post result allows us to send graphql IDs to the app to allow it to to look up the notification post via our `wp-graphql` endpoint. 